### PR TITLE
Remove functional dependencies from MonadChangeset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/changeset-lens/changeset-lens.cabal
+++ b/changeset-lens/changeset-lens.cabal
@@ -53,6 +53,7 @@ common opts
     StandaloneDeriving
     StrictData
     TupleSections
+    TypeApplications
     TypeOperators
 
 library

--- a/changeset-lens/src/Control/Monad/Changeset/Lens/At.hs
+++ b/changeset-lens/src/Control/Monad/Changeset/Lens/At.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Control.Monad.Changeset.Lens.At where
@@ -105,8 +106,8 @@ i <>\@ 'setJust' a
 i <>\@ 'setNothing'
 @
 -}
-(<>@) :: (MonadChangeset s (AtChangeset s w) m) => Index s -> w -> m ()
-index <>@ w = change $ atChangeset index w
+(<>@) :: forall s w m. (MonadChangeset s (AtChangeset s w) m) => Index s -> w -> m ()
+index <>@ w = change @s $ atChangeset @s index w
 
 {- | Set a value at a given index.
 
@@ -119,8 +120,8 @@ Example:
 i .@ a
 @
 -}
-(.@) :: (MonadChangeset s (AtChangeset s (MaybeChange (IxValue s))) m) => Index s -> IxValue s -> m ()
-index .@ w = index <>@ setJust w
+(.@) :: forall s m. (MonadChangeset s (AtChangeset s (MaybeChange (IxValue s))) m) => Index s -> IxValue s -> m ()
+index .@ w = (<>@) @s index (setJust w)
 
 {- | Lift an 'IxedChangeset' to an 'AtChangeset'.
 

--- a/changeset-lens/src/Control/Monad/Changeset/Lens/Ixed.hs
+++ b/changeset-lens/src/Control/Monad/Changeset/Lens/Ixed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Control.Monad.Changeset.Lens.Ixed where
@@ -93,8 +94,8 @@ Example:
 i |>! Increment
 @
 -}
-(|>!) :: (MonadChangeset s (IxedChangeset s w) m) => Index s -> w -> m ()
-index |>! w = change $ ixedChangeset index w
+(|>!) :: forall s w m. (MonadChangeset s (IxedChangeset s w) m) => Index s -> w -> m ()
+index |>! w = change @s $ ixedChangeset @s index w
 
 {- | Set a value at a given index.
 
@@ -107,5 +108,5 @@ Example:
 i .! a
 @
 -}
-(.!) :: (MonadChangeset s (IxedChangeset s (First (IxValue s))) m) => Index s -> IxValue s -> m ()
-index .! w = index |>! First (Just w)
+(.!) :: forall s m. (MonadChangeset s (IxedChangeset s (First (IxValue s))) m) => Index s -> IxValue s -> m ()
+index .! w = (|>!) @s index (First (Just w))

--- a/changeset-lens/src/Control/Monad/Changeset/Lens/Setter.hs
+++ b/changeset-lens/src/Control/Monad/Changeset/Lens/Setter.hs
@@ -62,8 +62,8 @@ Example:
 someLens |>~ Increment
 @
 -}
-(|>~) :: (MonadChangeset s (SetterChangeset s a w) m) => Setter' s a -> w -> m ()
-setter |>~ w = change $ setterChangeset setter w
+(|>~) :: forall s a w m. (MonadChangeset s (SetterChangeset s a w) m) => Setter' s a -> w -> m ()
+setter |>~ w = change @s $ setterChangeset setter w
 
 {- | Set a value through a setter.
 

--- a/changeset/src/Control/Monad/Changeset/Class.hs
+++ b/changeset/src/Control/Monad/Changeset/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | A type class generalising the API of 'Control.Monad.Trans.Changeset.ChangesetT'.
@@ -47,7 +48,7 @@ change w1 >> change w2 = change (w1 <> w2)
 current s1 >> current s2 = current s2
 @
 -}
-class (Monad m, Monoid w, RightAction w s) => MonadChangeset s w m | m -> s, m -> w where
+class (Monad m, Monoid w, RightAction w s) => MonadChangeset s w m where
   -- | Apply a changeset to the state.
   changeset ::
     -- | Receives the current state and has to output a value and a change.
@@ -61,26 +62,26 @@ class (Monad m, Monoid w, RightAction w s) => MonadChangeset s w m | m -> s, m -
   This is a special case of 'changeset' where the current state is disregarded.
   -}
   change :: w -> m ()
-  change w = changeset $ const ((), w)
+  change w = changeset @s $ const ((), w)
 
   {- | Observe the current state.
 
   This is a special case of 'changeset' where the state is not changed.
   -}
   current :: m s
-  current = changeset (,mempty)
+  current = changeset @s (, mempty @w)
 
 instance {-# OVERLAPPABLE #-} (Monad m, Monad (t m), MonadTrans t, MFunctor t, MonadChangeset s w m) => MonadChangeset s w (t m) where
   changeset = lift . changeset
-  change = lift . change
-  current = lift current
+  change = lift . change @s
+  current = lift $ current @s @w
 
 {- | Calculate the difference from the current state to the explicitly given state, and return it.
 
 Also see 'update'.
 -}
-diff :: (RightTorsor w s, MonadChangeset s w m) => s -> m w
-diff s = (`differenceRight` s) <$> current
+diff :: forall s w m. (MonadChangeset s w m, RightTorsor w s) => s -> m w
+diff s = (`differenceRight` s) <$> current @s @w
 
 {- | Update to a specific state.
 
@@ -88,5 +89,5 @@ This is only possible if the change is also a /torsor/, that is, there is a way 
 
 With a lawful @'RightTorsor' w s@ instance, it can be expected that after applying @'update' s@, the state is @s@.
 -}
-update :: (MonadChangeset s w m, RightTorsor w s) => s -> m ()
-update s = diff s >>= change
+update :: forall s w m. (MonadChangeset s w m, RightTorsor w s) => s -> m ()
+update s = diff s >>= change @s @w

--- a/changeset/src/Control/Monad/Trans/Changeset.hs
+++ b/changeset/src/Control/Monad/Trans/Changeset.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- | A general state monad transformer with separate types for the state and the possible changes, updates, commits, or diffs.
@@ -406,8 +407,8 @@ singleChange :: w -> Changes w
 singleChange = Changes . pure
 
 -- | Apply a single change.
-changeSingle :: (MonadChangeset s (Changes w) m) => w -> m ()
-changeSingle = change . singleChange
+changeSingle :: forall s w m. (MonadChangeset s (Changes w) m) => w -> m ()
+changeSingle = change @s @(Changes w) . singleChange
 
 -- | Apply all changes sequentially
 instance (RightAction w s) => RightAction (Changes w) s where


### PR DESCRIPTION
The functional dependency `m -> s, m -> w` makes implementing Rhine clocks in IO untenable.

Ambiguous types aren't fun, but they make the typeclass less restrictive.